### PR TITLE
feat: add ability to specify `entryType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ The following performance entry types are supported:
   Retrieve the `startTime` of a built-in paint measurement (e.g.
   `first-contentful-paint`).
 
+If you have multiple entries with the same name (for example, a `mark` and `measure` both named `foo`),
+then you can specify a particular `entryType` to narrow it down:
+
+```json
+"benchmarks": [
+  {
+    "measurement": {
+      "mode": "performance",
+      "entryName": "foo",
+      "entryType": "measure"
+    }
+  }
+]
+```
+
 #### Callback
 
 By default with local (non-URL) benchmarks, or when the `--measure` flag is set

--- a/config.schema.json
+++ b/config.schema.json
@@ -376,6 +376,14 @@
                 "entryName": {
                     "type": "string"
                 },
+                "entryType": {
+                    "enum": [
+                        "mark",
+                        "measure",
+                        "paint"
+                    ],
+                    "type": "string"
+                },
                 "mode": {
                     "enum": [
                         "performance"

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -70,7 +70,12 @@ async function queryForPerformanceEntry(
 ): Promise<number | undefined> {
   const escaped = escapeStringLiteral(measurement.entryName);
   const script = `return window.performance.getEntriesByName(\`${escaped}\`);`;
-  const entries = (await driver.executeScript(script)) as PerformanceEntry[];
+  let entries = (await driver.executeScript(script)) as PerformanceEntry[];
+  if (typeof measurement.entryType === 'string') {
+    entries = entries.filter(
+      (entry) => entry.entryType === measurement.entryType
+    );
+  }
   if (entries.length === 0) {
     return undefined;
   }

--- a/src/test/data/performance-measure-specific-entry-type.html
+++ b/src/test/data/performance-measure-specific-entry-type.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!--
+This test benchmark sets a performance API measurement after a delay.
+-->
+<html>
+  <head>
+    <title>performance measure test with specific entryType</title>
+  </head>
+  <body>
+    <script>
+      const params = new URL(document.location).searchParams;
+      const wait = Number(params.get('wait'));
+      const start = performance.mark('foo');
+      setTimeout(() => {
+        performance.measure('foo', 'foo');
+      }, wait);
+    </script>
+  </body>
+</html>

--- a/src/test/data/performance-measure-specific-entry-type.json
+++ b/src/test/data/performance-measure-specific-entry-type.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Polymer/tachometer/master/config.schema.json",
+  "sampleSize": 10,
+  "timeout": 0,
+  "benchmarks": [
+    {
+      "name": "20",
+      "url": "performance-measure-specific-entry-type.html?wait=20",
+      "measurement": {
+        "mode": "performance",
+        "entryName": "foo",
+        "entryType": "measure"
+      },
+      "browser": {
+        "name": "chrome",
+        "headless": true
+      }
+    },
+    {
+      "name": "60",
+      "url": "performance-measure-specific-entry-type.html?wait=60",
+      "measurement": {
+        "mode": "performance",
+        "entryName": "foo",
+        "entryType": "measure"
+      },
+      "browser": {
+        "name": "chrome",
+        "headless": true
+      }
+    }
+  ]
+}

--- a/src/test/e2e_test.ts
+++ b/src/test/e2e_test.ts
@@ -227,6 +227,41 @@ suite('e2e', function () {
       );
 
       test(
+        'performance entry with specific entryType',
+        hideOutput(async function () {
+          const delayA = 20;
+          const delayB = 60;
+
+          // TODO(aomarks) This isn't actually testing each browser, since
+          // the browser is hard coded in the config file. Generate the JSON
+          // file dynamically instead.
+          const argv = [
+            `--config=${path.join(
+              testData,
+              'performance-measure-specific-entry-type.json'
+            )}`,
+          ];
+
+          const actual = await main(argv);
+          assert.isDefined(actual);
+          assert.lengthOf(actual!, 2);
+          const [a, b] = actual!;
+          const diffAB = a.differences[1]!;
+          const diffBA = b.differences[0]!;
+
+          // We can't be very precise with expectations here, since
+          // setTimeout can be quite variable on a resource starved machine
+          // (e.g. some of our CI builds).
+          assert.isAtLeast(a.stats.mean, delayA);
+          assert.isAtLeast(b.stats.mean, delayB);
+          assert.isBelow(ciAverage(diffAB.absolute), 0);
+          assert.isAbove(ciAverage(diffBA.absolute), 0);
+          assert.isBelow(ciAverage(diffAB.relative), 0);
+          assert.isAbove(ciAverage(diffBA.relative), 0);
+        })
+      );
+
+      test(
         'multiple measurements',
         hideOutput(async function () {
           const delayA = 20;

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export interface CallbackMeasurement extends MeasurementBase {
 export interface PerformanceEntryMeasurement extends MeasurementBase {
   mode: 'performance';
   entryName: string;
+  entryType?: 'mark' | 'measure' | 'paint';
 }
 
 export interface ExpressionMeasurement extends MeasurementBase {


### PR DESCRIPTION
Resolves #214

This adds a new, optional key, `"entryType"`, to the `"measurement"` definition. If defined, this will filter performance entries by the given type.

I also added a test based on the existing test. The test fails without the code change, but succeeds with it.