### PR TITLE
fix: pass shell: true to run npm to avoid einval on windows

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,7 @@ export async function main(
 }
 
 async function latestVersionFromNpm(): Promise<string> {
-  const stdout = await runNpm(['info', 'tachometer@latest', 'version']);
+  const stdout = await runNpm(['info', 'tachometer@latest', 'version'], { shell: true });
   return stdout.toString('utf8').trim();
 }
 


### PR DESCRIPTION
reference: https://github.com/nodejs/node/issues/52554

On windows, one would get
![image](https://github.com/user-attachments/assets/ef12bb26-fb0b-45f7-a07e-9e3aef7883f2)

This PR fixes as per the recommendation in https://github.com/nodejs/node/issues/52554
